### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 dictime 
 -------
 
-[![Build Status](https://secure.travis-ci.org/stevepeak/dictime.png)](http://travis-ci.org/stevepeak/dictime) [![Version](https://pypip.in/v/dictime/badge.png)](https://github.com/stevepeak/dictime) [![codecov.io](https://codecov.io/github/stevepeak/dictime/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/dictime?branch=master)
+[![Build Status](https://secure.travis-ci.org/stevepeak/dictime.png)](http://travis-ci.org/stevepeak/dictime) [![Version](https://img.shields.io/pypi/v/dictime.svg)](https://github.com/stevepeak/dictime) [![codecov.io](https://codecov.io/github/stevepeak/dictime/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/dictime?branch=master)
 
 > Time dimensional dictionaries, featuring expiring and future key values.
 >  `dictime` extends the standard python `dict` with **3** distinct additions


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20dictime))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `dictime`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.